### PR TITLE
Update Travis CI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Federico Voges <fvoges@gmail.com>
 
 ##Support
 
-Please report issues on the [project page](http://github.com/fvoges/fvoges-motd/issues).
+Please report issues on the [project page](http://github.com/fvoges/puppet-motd/issues).
 
 Pull requests are welcome :)
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #motd
 
-[![Build Status](https://travis-ci.org/fvoges/fvoges-motd.svg)](https://travis-ci.org/fvoges/fvoges-motd)
+[![Build Status](https://travis-ci.org/fvoges/puppet-motd.svg)](https://travis-ci.org/fvoges/puppet-motd)
 
 ##Overview
 


### PR DESCRIPTION
update Travis CI badge URL
To test, check that the badge is not grey