### PR TITLE
Remove Ruby 1.9.3 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: ruby
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.0


### PR DESCRIPTION
To test, Travis CI runs should not use Ruby 1.9.3 any more