### PR TITLE
Remove all Ruby versions from test matrix except 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ language: ruby
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 rvm:
-  - 2.0.0
   - 2.1.0
-  - 2.2.0
-  - 2.3.0
+#  - 2.2.0
+#  - 2.3.0
 script: bundle exec rake test
 env:
   - PUPPET_VERSION="~> 3.2.0"


### PR DESCRIPTION
To test, verify that Travis CI only uses Ruby 2.1.0 for the tests